### PR TITLE
Support for JS Consumers; examples

### DIFF
--- a/example/js/example-bs-ajv-from-js-async.js
+++ b/example/js/example-bs-ajv-from-js-async.js
@@ -1,106 +1,121 @@
 const Ajv = require('../../src/Ajv.bs');
 
-const invalidData = { "messages": {
-  "Dr. Beverly Crusher": "How are you feeling!",
-  "Cpt. Jean-Luc Picard": "No children allowed on the bridge?",
-  "Lt. Cmdr. Data": "I am an android!",
-}};
-const validData = { "messages": {
-  "Dr. Beverly Crusher": "How are you feeling?",
-  "Cpt. Jean-Luc Picard": "No children allowed on the bridge!",
-  "Lt. Cmdr. Data": "I am an android.",
-}};
+const invalidData = { username: 'scull7' };
+const validData = { username: 'johndoe123' };
 
 const schema = {
   "$async": true,
   "title": "Message",
   "type": "object",
-  "customKeyword": "custom parameter string",
+  "required": [
+    "username"
+  ],
   "properties": {
-    "messages": {
-      "type": "object",
-      "maxProperties": 3,
-      "minProperties": 1,
-      "additionalProperties": false,
-      "patternProperties": {
-        "Dr\\. .*": {
-          "type": "string",
-          "pattern": "^.*\\?$"
-        },
-        "Cpt\\. .*": {
-          "type": "string",
-          "pattern": "^.*!$"
-        },
-        "Lt. Cmdr. .*": {
-          "type": "string",
-          "pattern": "^.*[\.?]$"
-        },
-        "Act. Ens. .*": {
-          "type": "string",
-          "pattern": "^$"
-        }
-      }
+    "username": {
+      "type": "string",
+      /* Our custom keyword! */
+      "userExists": false
     }
   },
-  "required": [
-    "messages"
-  ]
 };
 
-/* Using bs-ajv from Javascript. TODO is this interface too complicated? */
-/* Define async validator for custom keyword */
-/* TODO what argument is _ ? */
-function asyncValidator(schema, data, _) {
-  console.log('asyncValidator got schema=', schema);
-  console.log('asyncValidator got data=', data);
-  /* Mock request latency */
+/* Instantiate an Ajv.Options.t. */
+const ajvOptions = new Ajv.makeOptions();
+/* Request all errors (the alternative fails early, but underreports
+ * validation errors)
+ */
+Ajv.setOptionAllErrors(ajvOptions, true);
+/* Request that the dataPath property of native Ajv error objects use JSON
+ * Pointers to reference subdocuments which failed to validate!  Even
+ * though you will probably only be consuming bs-ajv's errors and not Ajv's
+ * own error objects, this is CRITICAL. In a future version, bs-ajv may
+ * enforce this option!
+ */
+Ajv.setOptionJsonPointers(ajvOptions, true);
+Ajv.setOptionRemoveAdditional(ajvOptions, true);
+
+/* JSON Schema's own validation keywords do not cover all of our validation
+ * needs. To address this, we will create a custom validation keyword. The
+ * validation criterion asserted by this custom keyword are defined by a
+ * function we supply.  This function can be asynchronous (Promise) or
+ * synchronous. 
+ *
+ * For more documentation on this function, see the Ajv docs:
+ * https://github.com/epoberezkin/ajv/blob/master/CUSTOM.md#define-keyword-with-validation-function
+ */
+function validateUserExists(schema, data) {
+  /* Mock user database! */
+  const users = [
+    { username: 'scull7' }
+  ];
   return new Promise((resolve, reject) => {
+    /* Mock request latency */
     setTimeout(() => {
-      resolve(true);
+      /* Does user exist? */
+      const userExists = users.some(({username}) => username == data);
+      /* schema === false because that's the property value within our
+       * application of our custom keyword in our schema.
+       */
+      resolve(schema === userExists);
     }, 1000);
   })
 }
-/* Instantiate an Ajv.Options.t -- just an empty JS object */
-const ajvOptions = new Ajv.makeOptions();
-Ajv.setOptionAllErrors(ajvOptions, true);
-Ajv.setOptionJsonPointers(ajvOptions, true);
-Ajv.setOptionRemoveAdditional(ajvOptions, true);
-console.log('ajvOptions=', typeof ajvOptions);
-/* Instantiate custom validation keyword */
-/* TODO does this just create an empty object with Object.prototype prototype? */
-const customKeyword = Ajv.makeKeyword();
-console.log('customKeyword constructor name=', customKeyword.constructor.name);
-console.log('customKeyword prototype is Object.prototype=', customKeyword.__proto__ === Object.prototype);
-/* Set asynchronous validator for custom keyword */
-Ajv.setKeywordType(customKeyword, "object");
-Ajv.setKeywordIsAsync(customKeyword, true);
-Ajv.setValidator(customKeyword, asyncValidator);
-/* Instantiate validator factory */
-/* TODO does this just create an empty object with Object.prototype prototype? */
-const ajv = Ajv.makeAjv(ajvOptions);
-console.log('ajv=', typeof ajv);
-/* Add custom keyword to validator factory */
-console.log('customKeyword=', customKeyword);
-Ajv.addKeyword("customKeyword", customKeyword, ajv);
-/* Instantiate asynchronous validator */
-const validator = Ajv.compileAsync(schema, ajv);
-console.log('validator=', typeof validator);
-/* Evalutae example document against asynchronous validator */
-validator(invalidData)
-.then(result => {
-  console.log('UNEXPECTED RESULT validator result=', result);
-}).catch(err => {
-  console.error("EXPECTED RESULT validator error=", err);
-}).then(() => {
-  console.log('async validating...');
-  return validator(validData)
-}).then(result => {
-  console.log('EXPECTED RESULT validator result=', result);
-}).catch(err => {
-  console.error("UNEXPECTED RESULT validator error=", err);
-}).then(() => {
-  /* goodbye.wav */
-  console.log('normal exit');
-});
+/*
+ * We will define a custom keyword which extends the capabilities of
+ * JSON schema.
+ */
+const userExistsKeyword = Ajv.makeKeyword();
+/* Our custom keyword only applies to strings. We can specify that like so.
+ * If the type doesn't match, the keyword is assumed to validate.
+ */
+Ajv.setKeywordType(userExistsKeyword, "string");
+/* Our custom keyword's validation implementation is asynchronous. We must
+ * configure it as such:
+ */
+Ajv.setKeywordIsAsync(userExistsKeyword, true);
+/* Now let's attach our validator function to our custom keyword's
+ * definition
+ */
+Ajv.setValidator(userExistsKeyword, validateUserExists);
 
-console.log('async validating...');
+/* Instantiate Ajv.
+ *
+ * From this object, we can compile any number of schemas into document
+ * validation functions, or extend the capabilities of any such schemas. We
+ * only need to do this once.
+ * 
+ * DO NOT DO THIS every time you need to validate a document!
+ */
+const ajv = Ajv.makeAjv(ajvOptions);
+/* Add our custom keyword definition */
+Ajv.addKeyword("userExists", userExistsKeyword, ajv);
+
+/* Now we can compile a schema to a document validation function!
+ *
+ * Just like before, we only need to do this ONCE PER SCHEMA!
+ *
+ * DO NOT DO THIS every time you need to validate a document!
+ */
+const validate = Ajv.compileAsync(schema, ajv);
+
+/* Now let's validate some documents! Remember that in this example, our
+ * schema includes a custom validation keyword whose implementation
+ * executes asynchronously using Promise.
+ */
+async function example() {
+  try {
+    console.log('\nthis document is expected to fail validation:');
+    let validatedDocument = await validate(invalidData)
+  } catch (e) {
+    console.error(e);
+  }
+  try {
+    console.log('\nthis document is expected to pass validation:');
+    let validatedDocument = await validate(validData)
+    console.log(validatedDocument);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+example();

--- a/example/js/example-bs-ajv-from-js-async.js
+++ b/example/js/example-bs-ajv-from-js-async.js
@@ -1,0 +1,106 @@
+const Ajv = require('../../src/Ajv.bs');
+
+const invalidData = { "messages": {
+  "Dr. Beverly Crusher": "How are you feeling!",
+  "Cpt. Jean-Luc Picard": "No children allowed on the bridge?",
+  "Lt. Cmdr. Data": "I am an android!",
+}};
+const validData = { "messages": {
+  "Dr. Beverly Crusher": "How are you feeling?",
+  "Cpt. Jean-Luc Picard": "No children allowed on the bridge!",
+  "Lt. Cmdr. Data": "I am an android.",
+}};
+
+const schema = {
+  "$async": true,
+  "title": "Message",
+  "type": "object",
+  "customKeyword": "custom parameter string",
+  "properties": {
+    "messages": {
+      "type": "object",
+      "maxProperties": 3,
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "Dr\\. .*": {
+          "type": "string",
+          "pattern": "^.*\\?$"
+        },
+        "Cpt\\. .*": {
+          "type": "string",
+          "pattern": "^.*!$"
+        },
+        "Lt. Cmdr. .*": {
+          "type": "string",
+          "pattern": "^.*[\.?]$"
+        },
+        "Act. Ens. .*": {
+          "type": "string",
+          "pattern": "^$"
+        }
+      }
+    }
+  },
+  "required": [
+    "messages"
+  ]
+};
+
+/* Using bs-ajv from Javascript. TODO is this interface too complicated? */
+/* Define async validator for custom keyword */
+/* TODO what argument is _ ? */
+function asyncValidator(schema, data, _) {
+  console.log('asyncValidator got schema=', schema);
+  console.log('asyncValidator got data=', data);
+  /* Mock request latency */
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve(true);
+    }, 1000);
+  })
+}
+/* Instantiate an Ajv.Options.t -- just an empty JS object */
+const ajvOptions = new Ajv.makeOptions();
+Ajv.setOptionAllErrors(ajvOptions, true);
+Ajv.setOptionJsonPointers(ajvOptions, true);
+Ajv.setOptionRemoveAdditional(ajvOptions, true);
+console.log('ajvOptions=', typeof ajvOptions);
+/* Instantiate custom validation keyword */
+/* TODO does this just create an empty object with Object.prototype prototype? */
+const customKeyword = Ajv.makeKeyword();
+console.log('customKeyword constructor name=', customKeyword.constructor.name);
+console.log('customKeyword prototype is Object.prototype=', customKeyword.__proto__ === Object.prototype);
+/* Set asynchronous validator for custom keyword */
+Ajv.setKeywordType(customKeyword, "object");
+Ajv.setKeywordIsAsync(customKeyword, true);
+Ajv.setValidator(customKeyword, asyncValidator);
+/* Instantiate validator factory */
+/* TODO does this just create an empty object with Object.prototype prototype? */
+const ajv = Ajv.makeAjv(ajvOptions);
+console.log('ajv=', typeof ajv);
+/* Add custom keyword to validator factory */
+console.log('customKeyword=', customKeyword);
+Ajv.addKeyword("customKeyword", customKeyword, ajv);
+/* Instantiate asynchronous validator */
+const validator = Ajv.compileAsync(schema, ajv);
+console.log('validator=', typeof validator);
+/* Evalutae example document against asynchronous validator */
+validator(invalidData)
+.then(result => {
+  console.log('UNEXPECTED RESULT validator result=', result);
+}).catch(err => {
+  console.error("EXPECTED RESULT validator error=", err);
+}).then(() => {
+  console.log('async validating...');
+  return validator(validData)
+}).then(result => {
+  console.log('EXPECTED RESULT validator result=', result);
+}).catch(err => {
+  console.error("UNEXPECTED RESULT validator error=", err);
+}).then(() => {
+  /* goodbye.wav */
+  console.log('normal exit');
+});
+
+console.log('async validating...');

--- a/example/js/example-bs-ajv-from-js-sync.js
+++ b/example/js/example-bs-ajv-from-js-sync.js
@@ -1,0 +1,81 @@
+const Ajv = require('../../src/Ajv.bs');
+
+const invalidData = { "messages": {
+  "Dr. Beverly Crusher": "How are you feeling!",
+  "Cpt. Jean-Luc Picard": "No children allowed on the bridge?",
+  "Lt. Cmdr. Data": "I am an android!",
+}};
+
+const schema = {
+  "title": "Message",
+  "type": "object",
+  "customKeyword": "custom parameter string",
+  "properties": {
+    "messages": {
+      "type": "object",
+      "maxProperties": 3,
+      "minProperties": 1,
+      "additionalProperties": false,
+      "patternProperties": {
+        "Dr\\. .*": {
+          "type": "string",
+          "pattern": "^.*\\?$"
+        },
+        "Cpt\\. .*": {
+          "type": "string",
+          "pattern": "^.*!$"
+        },
+        "Lt. Cmdr. .*": {
+          "type": "string",
+          "pattern": "^.*[\.?]$"
+        },
+        "Act. Ens. .*": {
+          "type": "string",
+          "pattern": "^$"
+        }
+      }
+    }
+  },
+  "required": [
+    "messages"
+  ]
+};
+
+/* Using bs-ajv from Javascript. TODO is this interface too complicated? */
+/* Define sync validator for custom keyword */
+/* TODO what argument is _ ? */
+function syncValidator(schema, data, _) {
+  console.log('**** syncValidator got schema=', schema);
+  console.log('**** syncValidator got data=', data);
+  return true;
+}
+/* Instantiate an Ajv.Options.t -- just an empty JS object */
+const ajvOptions = new Ajv.makeOptions();
+Ajv.setOptionAllErrors(ajvOptions, true);
+Ajv.setOptionJsonPointers(ajvOptions, true);
+Ajv.setOptionRemoveAdditional(ajvOptions, true);
+console.log('ajvOptions=', typeof ajvOptions);
+/* Instantiate custom validation keyword */
+/* TODO does this just create an empty object with Object.prototype prototype? */
+const customKeyword = Ajv.makeKeyword();
+console.log('customKeyword constructor name=', customKeyword.constructor.name);
+console.log('customKeyword prototype is Object.prototype=', customKeyword.__proto__ === Object.prototype);
+/* Set synchronous validator for custom keyword */
+Ajv.setKeywordType(customKeyword, "object");
+Ajv.setKeywordIsAsync(customKeyword, false);
+Ajv.setValidator(customKeyword, syncValidator);
+/* Instantiate validator factory */
+/* TODO does this just create an empty object with Object.prototype prototype? */
+const ajv = Ajv.makeAjv(ajvOptions);
+console.log('ajv=', typeof ajv);
+/* Add custom keyword to validator factory */
+console.log('customKeyword=', customKeyword);
+Ajv.addKeyword("customKeyword", customKeyword, ajv);
+/* Instantiate synchronous validator */
+const validator = Ajv.compileSync(schema, ajv);
+console.log('validator=', typeof validator);
+/* Evalutae example document against synchronous validator */
+const result = validator(invalidData);
+console.log('result=', result);
+/* goodbye.wav */
+console.log('normal exit');


### PR DESCRIPTION
Please see the new async example and let me know if it's alright.

https://github.com/dvisztempacct/bs-ajv/blob/55d135bf70729ed34367b0ad096a7e815e703c8c/example/js/example-bs-ajv-from-js-async.js

My plan was to make the sync validation example be as similar to this as possible. What do you think?